### PR TITLE
removes an obsolete? if statement

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -151,11 +151,7 @@ function mtime(filePath) {
       // Used to speed up file stats. Modifies the `statValues` typed array,
       // with index 11 being the mtime milliseconds stamp. The speedup comes
       // from not creating Stat objects.
-      if (useInternalStatValues) {
-        internalStat(filePath)
-      } else {
-        internalStat(filePath, statValues)
-      }
+      internalStat(filePath, statValues)
       return statValues[11]
     } catch (e) {
       if (e.code === "ENOENT") {


### PR DESCRIPTION
`useInternalStatValues` is not defined anywhere