### PR TITLE
Added note to README that named imports work for CommonJS modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,17 @@ undefined
 'hello/world'
 ```
 
+Note: The REPL mode also enables CommonJS features so destructuring `import` works in the REPL for both CommonJS and ES modules:
+```shell
+$ node
+> require("@std/esm")
+@std/esm enabled
+> import { join } from "path"
+undefined
+> join("hello", "world")
+'hello/world'
+```
+
 Standard Features
 ---
 


### PR DESCRIPTION
Just a note for #57 that `import { namedExport } from "commonjs"` works in the REPL.