### PR TITLE
Add instruction to include .esm-cache in .gitignore

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Getting started
      require("@std/esm")
      module.exports = require("./main.mjs").default
      ```
+  3. Add `.esm-cache` to your `.gitignore`.
 
 For package authors with sub modules:
 


### PR DESCRIPTION
Per @jdalton in #69 it is recommended to add `.esm-cache` to `.gitignore`.