### PR TITLE
use .babelrc.js instead of deprecated .babelrc

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -1,18 +1,22 @@
-{
-  "plugins": [
+"use strict"
+
+const isTest = /test/.test(process.env.NODE_ENV)
+
+module.exports = {
+  plugins: [
     ["@babel/proposal-class-properties", {
-      "loose": true
+      loose: true
     }],
     ["@babel/transform-block-scoping", {
-      "throwIfClosureRequired": false
+      throwIfClosureRequired: false
     }],
     "transform-for-of-as-array"
   ],
-  "presets": [
+  presets: [
     ["@babel/env", {
-      "loose": true,
-      "modules": false,
-      "exclude": [
+      loose: true,
+      modules: false,
+      exclude: [
         "transform-async-to-generator",
         "transform-classes",
         "transform-for-of",
@@ -20,7 +24,8 @@
         "transform-object-super",
         "transform-regenerator"
       ],
-      "targets": { "node": 4 }
+      targets: { node: 4 },
+      debug: isTest
     }]
   ]
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -34,8 +34,7 @@ const config = {
     rules: [{
       test: /\.js$/,
       loader: "babel-loader",
-      exclude: /node_modules/,
-      options: readJSON("./.babelrc")
+      exclude: /node_modules/
     }]
   },
   plugins: [
@@ -79,7 +78,6 @@ if (isTest) {
   config.entry.compiler = "./src/compiler.js"
   config.entry.runtime = "./src/runtime.js"
   config.entry["url-to-path"] = "./src/util/url-to-path.js"
-  config.module.rules[0].options.presets[0][1].debug = true
 }
 
 module.exports = config


### PR DESCRIPTION
babelrc is (soon to be deprecated and) replaced by babelrc.js, which is similar to eslintrc.js

see: https://babeljs.io/blog/2017/09/12/planning-for-7.0

that also makes the _debug_ injection for babel config options more straightforward, and babelrc doesn't need to be explicitly required.

as a side note:

I got a _git commit_ hook exception from eslint:
```
/dev/github/esm_fork/test/fixture/scenario/jest/__tests__/test.js
  6:2  error  'expect' is not defined  no-undef

✖ 1 problem (1 error, 0 warnings)
```

do you want to add _expect_ to the eslint allowed globals, or rather have the folder or file in eslintignore?