### PR TITLE
Use acorn to get the position where to inser the id of an anonymous function decl

### DIFF
--- a/src/acorn-ext/function-params-start.js
+++ b/src/acorn-ext/function-params-start.js
@@ -1,0 +1,13 @@
+import wrap from "../util/wrap.js"
+
+function enable(parser) {
+  parser.parseFunctionParams = wrap(parser.parseFunctionParams, parseFunctionParams)
+  return parser
+}
+
+function parseFunctionParams(func, [ node ]) {
+  node.functionParamsStart = this.start
+  return func.call(this, node)
+}
+
+export { enable }

--- a/src/parser.js
+++ b/src/parser.js
@@ -4,6 +4,7 @@ import _createOptions from "./util/create-options.js"
 import { enable as enableAwaitAnywhere } from "./acorn-ext/await-anywhere.js"
 import { enable as enableAwaitGenerator } from "./acorn-ext/async-generator.js"
 import { enable as enableDynamicImport } from "./acorn-ext/dynamic-import.js"
+import { enable as enableFunctionParamsStart } from "./acorn-ext/function-params-start.js"
 import { enable as enableHTMLComment } from "./acorn-ext/html-comment.js"
 import { enable as enableObjectRestSpread } from "./acorn-ext/object-rest-spread.js"
 import { enable as enableTolerance } from "./acorn-ext/tolerance.js"
@@ -32,6 +33,7 @@ function extend(parser) {
   enableAwaitAnywhere(parser)
   enableAwaitGenerator(parser)
   enableDynamicImport(parser)
+  enableFunctionParamsStart(parser)
   enableHTMLComment(parser)
   enableObjectRestSpread(parser)
   enableTolerance(parser)

--- a/src/visitor/import-export.js
+++ b/src/visitor/import-export.js
@@ -10,8 +10,6 @@ const codeOfCR = "\r".charCodeAt(0)
 
 const { keys } = Object
 
-const functionPrefixRe = /^\s*(?:async\s*)?function(?:\s*\*)?/
-
 class ImportExportVisitor extends Visitor {
   finalizeHoisting() {
     if (this.bodyInfo === null) {
@@ -131,19 +129,16 @@ class ImportExportVisitor extends Visitor {
 
     const node = path.getValue()
     const { declaration } = node
-    const { id, type } = declaration
+    const { id, type, functionParamsStart } = declaration
 
     if (type === "FunctionDeclaration" ||
         (id && type === "ClassDeclaration")) {
       const name = id ? id.name : encodeId("default")
 
       if (! id) {
-        const source = this.code.slice(declaration.start, declaration.end)
-        const prefixLength = source.match(functionPrefixRe)[0].length
-
         this.madeChanges = true
         this.magicString.prependRight(
-          declaration.start + prefixLength,
+          functionParamsStart,
           " " + name
         )
       }

--- a/test/output/anon-async-function/actual.mjs
+++ b/test/output/anon-async-function/actual.mjs
@@ -1,1 +1,8 @@
-export default async   function   () {}
+export default
+// Comment 1
+/* Comment
+2 */
+async /* Comment 3 */  function 
+/* Comment 4
+*/ // Comment 5
+() {}

--- a/test/output/anon-async-function/expected.mjs
+++ b/test/output/anon-async-function/expected.mjs
@@ -1,1 +1,8 @@
-_.e([["default",()=>default]]);async   function default   () {}
+_.e([["default",()=>default]]);
+
+
+
+async /* Comment 3 */  function 
+/* Comment 4
+*/ // Comment 5
+ default() {}

--- a/test/output/anon-function/actual.mjs
+++ b/test/output/anon-function/actual.mjs
@@ -1,1 +1,8 @@
-export default function() {}
+export default 
+// Comment 1
+/* Comment
+2 */ function 
+// Comment 3
+/* Comment
+4 */
+() {}

--- a/test/output/anon-function/expected.mjs
+++ b/test/output/anon-function/expected.mjs
@@ -1,1 +1,8 @@
-_.e([["default",()=>default]]);function default() {}
+_.e([["default",()=>default]]);
+
+
+function 
+// Comment 3
+/* Comment
+4 */
+ default() {}

--- a/test/output/anon-generator/actual.mjs
+++ b/test/output/anon-generator/actual.mjs
@@ -1,1 +1,16 @@
-export default function    *() {}
+export default 
+
+// Comment 1
+/* Comment
+2 */
+function  
+
+// Comment 3
+/* Comment
+4 */  *
+
+// Comment 5
+/* Comment
+6 */
+
+() {}

--- a/test/output/anon-generator/expected.mjs
+++ b/test/output/anon-generator/expected.mjs
@@ -1,1 +1,16 @@
-_.e([["default",()=>default]]);function    * default() {}
+_.e([["default",()=>default]]);
+
+
+
+
+function  
+
+// Comment 3
+/* Comment
+4 */  *
+
+// Comment 5
+/* Comment
+6 */
+
+ default() {}


### PR DESCRIPTION
A bug with the regexp I used in https://github.com/standard-things/esm/pull/187 was reported at https://github.com/rollup/rollup/issues/1798.
This PR implements an Acorn plugin to get the position of the parameters start, where the `default` is should be inserted.