### PR TITLE
README.md clarify top-level await usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Commonly used options may be specified in shorthand form:
 <tr>
   <td valign="top"><code>"await":</code></td>
   <td>
-    <p>A boolean to support top-level <code>await</code> in the main ES module.</p>
+    <p>A boolean to support top-level <code>await</code> in the main module <i>(requires <code>Node v7.6+</code>)</i>.</p>
   </td>
 </tr>
 <tr>


### PR DESCRIPTION
follow up from: https://github.com/standard-things/esm/issues/199

clarification for top-level _await_ support in ESM and CJS, also noting that Node v7.6+ is required.