### PR TITLE
adding test case for bug when comment is preceding import()

### DIFF
--- a/test/dynamic-import-tests.mjs
+++ b/test/dynamic-import-tests.mjs
@@ -127,4 +127,15 @@ describe("dynamic import", () => {
       assert.throws(() => compile(code), SyntaxError)
     )
   })
+
+  // bug: https://github.com/standard-things/esm/issues/203
+  it("should not error when using comment before import()", () =>
+    Promise.all([
+      "./fixture/comment/single-line.js",
+      "./fixture/comment/multi-line.js"
+    ].map((id) =>
+      import(id)
+        .then(() => assert.ok(true))
+    ))
+  )
 })

--- a/test/fixture/comment/multi-line.js
+++ b/test/fixture/comment/multi-line.js
@@ -1,0 +1,2 @@
+/* some comment */
+import("../export/const.mjs")

--- a/test/fixture/comment/single-line.js
+++ b/test/fixture/comment/single-line.js
@@ -1,0 +1,2 @@
+// some comment
+import("../export/const.mjs")


### PR DESCRIPTION
failing test case for https://github.com/standard-things/esm/issues/203

**note:** 1st test run without cache works, 2nd test run with _cache_ fails.

``` js
Promise
  .all([
    cleanRepo(),
    setupNode()
  ])
  .then(() => runTests()) // works
  .then(() => runTests(true)) // fails
```