### PR TITLE
adding tests for import() being a 'syntactic form'

### DIFF
--- a/test/dynamic-import-tests.mjs
+++ b/test/dynamic-import-tests.mjs
@@ -101,13 +101,22 @@ describe("dynamic import", () => {
     assert.ok(p())
   })
 
+  it("should be syntactic form and not a function", () => {
+    const invalids = [
+      "const func = import",
+      "import.call()",
+      "import.toString()"
+    ]
+
+    invalids.forEach((code) =>
+      assert.throws(() => compile(code), SyntaxError)
+    )
+  })
   it("should expect exactly one argument", () => {
     const invalids = [
       "import()",
       "import(a,b)",
       "import(...[a])",
-      "import.then()",
-      "import.call(a,b)"
     ]
 
     invalids.forEach((code) =>


### PR DESCRIPTION
added some tests which should not be allowed if _import()_ is not a function. Not sure if any already exist.

removed 2 parameters to the _one argument only_ tests, because they fail for a different reason: moved _call_ to syntactic form tests, and removed .then because it's unrelated to arguments as well (unless the test is looking for import not having a test prototype method - but even in that case it would be not related to arguments).

I'd also like to move the spread test, since it's more or less also unrelated, at least in the case of having at least _one argument_ ( import(...['./some-file'] ). I think the latest on that matter is that the spread operator is just not allowed.

_regarding the test description_:
Domenic Denicola's proposal mentions a _syntactic form_ https://github.com/tc39/proposal-dynamic-import
Axel Rauschmayer calls it an _operator_ http://2ality.com/2017/01/import-operator.html

_edited: made a mistake regarding the spread operator_