### PR TITLE
Add custom runner tip for Jasmine

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ Tips
   [`node-tap`](http://www.node-tap.org/cli/)
 * Load `@std/esm` with the `--node-args="-r @std/esm"` option of
   [`pm2`](http://pm2.keymetrics.io/docs/usage/quick-start/#options)
+* Load `@std/esm` in a custom runner [as in the documentation](https://jasmine.github.io/setup/nodejs.html#a-simple-example-using-the-library) for [`jasmine`](https://jasmine.github.io/)
 * Use `"@std/esm":"cjs"` with the `--watch` and `--watch-extensions` options of
   [`mocha`](https://mochajs.org/#-w---watch)
 * Use `"@std/esm":"cjs"` with [`webpack`](https://github.com/webpack/webpack)


### PR DESCRIPTION
Since Jasmine loads each spec script directly to run it, it requires @std/esm be loaded by a custom runner such as the following:

```javascript
require = require("@std/esm")(module);

const Jasmine = require('jasmine');
const jasmine = new Jasmine();

jasmine.execute();
```

I linked to the Jasmine documentation rather than include a large blurb like the above to maintain the current style of the document.