### PR TITLE
added babel scenario tests with reversed require

### DIFF
--- a/test/fixture/scenario/babel-register-flow/index-reverse.js
+++ b/test/fixture/scenario/babel-register-flow/index-reverse.js
@@ -1,0 +1,5 @@
+"use strict"
+
+require("@babel/register")
+require = require("../../../../")(module)
+require("./main.js")

--- a/test/scenario-tests.mjs
+++ b/test/scenario-tests.mjs
@@ -31,12 +31,57 @@ describe("scenarios", function () {
       .then(() => exec(nodePath, [indexPath]))
   })
 
+  it("should work with babel-register and plugins (code, reversed require)", () => {
+    const dirPath = path.resolve(testPath, "fixture/scenario/babel-register-flow")
+    const cachePath = path.resolve(dirPath, "node_modules/.cache")
+    const indexPath = path.resolve(dirPath, "index-reverse.js")
+
+    return Promise.resolve()
+      .then(() => trash(cachePath))
+      .then(() => exec(nodePath, [indexPath]))
+  })
+
   it("should work with babel-register and plugins (flag)", () => {
     const dirPath = path.resolve(testPath, "fixture/scenario/babel-register-flow")
+    const cachePath = path.resolve(dirPath, "node_modules/.cache")
     const mainPath = path.resolve(dirPath, "main.js")
     const nodeArgs = ["-r", pkgPath, "-r", "@babel/register", mainPath]
 
     return Promise.resolve()
+      .then(() => trash(cachePath))
+      .then(() => exec(nodePath, nodeArgs))
+  })
+
+  it("should work with babel-register and plugins (flag, reverse require)", () => {
+    const dirPath = path.resolve(testPath, "fixture/scenario/babel-register-flow")
+    const cachePath = path.resolve(dirPath, "node_modules/.cache")
+    const mainPath = path.resolve(dirPath, "main.js")
+    const nodeArgs = ["-r", "@babel/register", "-r", pkgPath, mainPath]
+
+    return Promise.resolve()
+      .then(() => trash(cachePath))
+      .then(() => exec(nodePath, nodeArgs))
+  })
+
+  it("should work with babel-register and plugins (code and flag double hook)", () => {
+    const dirPath = path.resolve(testPath, "fixture/scenario/babel-register-flow")
+    const cachePath = path.resolve(dirPath, "node_modules/.cache")
+    const mainPath = path.resolve(dirPath, "index.js")
+    const nodeArgs = ["-r", pkgPath, "-r", "@babel/register", mainPath]
+
+    return Promise.resolve()
+      .then(() => trash(cachePath))
+      .then(() => exec(nodePath, nodeArgs))
+  })
+
+  it("should work with babel-register and plugins (code and flag double hook, reverse require)", () => {
+    const dirPath = path.resolve(testPath, "fixture/scenario/babel-register-flow")
+    const cachePath = path.resolve(dirPath, "node_modules/.cache")
+    const mainPath = path.resolve(dirPath, "index.js")
+    const nodeArgs = ["-r", "@babel/register", "-r", pkgPath, mainPath]
+
+    return Promise.resolve()
+      .then(() => trash(cachePath))
       .then(() => exec(nodePath, nodeArgs))
   })
 


### PR DESCRIPTION
scenario tests for https://github.com/standard-things/esm/issues/252

I also noticed that (some) of the current tests might be flawed:
- the first babel test is creating cached files, and any subsequent test using the same fixture is picking those up
- **to _temporary_ mitigate the behavior I removed the cached files, though it's causing another problem for the subsequent caching run**

**would it be better to create a new test fixture for each test case, so it creates it's own cache folder?**

I also added a couple double hook tests, same (similar) to the ones for pm2. might be better to test double hooks also with _plain_ node - then, on failure, it might be easier to debug and fix, instead of thinking the issue might be caused by pm2.