### PR TITLE
change babel preset target to node 6

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -37,7 +37,7 @@ module.exports = {
       ],
       loose: true,
       modules: false,
-      targets: { node: 4 }
+      targets: { node: 6 }
     }]
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "esm",
-  "version": "0.25.2",
+  "version": "3.0.0",
   "description": "Tomorrow's ESM, today.",
   "keywords": "commonjs, ecmascript, export, import, modules, node, require",
   "repository": "standard-things/esm",


### PR DESCRIPTION
minimum supported node version is [v6.0](https://github.com/standard-things/esm/releases/tag/0.23.0). this changes the babel preset target to node 6.

_edit:_

plugin usage changes from:

transform-arrow-functions { "node":"4" }
transform-block-scoping { "node":"4" }
transform-destructuring { "node":"4" }
transform-parameters { "node":"4" }
transform-spread { "node":"4" }
transform-sticky-regex { "node":"4" }
transform-unicode-regex { "node":"4" }
transform-exponentiation-operator { "node":"4" }
transform-dotall-regex { "node":"4" }

to:

transform-destructuring { "node":"6" }
transform-exponentiation-operator { "node":"6" }
transform-dotall-regex { "node":"6" }