### PR TITLE
remove some explicitly excluded transforms

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -35,12 +35,8 @@ module.exports = {
       debug: isTest,
       exclude: [
         "transform-async-to-generator",
-        "transform-classes",
         "transform-for-of",
         "transform-function-name",
-        "transform-object-super",
-        "transform-new-target",
-        "transform-regenerator"
       ],
       loose: true,
       modules: false,


### PR DESCRIPTION
sorry, I missed those in the previous PR :/

remove some explicitly excluded transforms as they are not in the env preset for node:6

btw, I saw you added some transforms which are supported in V8 in node v6.0 back:

transform-arrow-functions
transform-block-scoping
transform-parameters
transform-spread

Is that for performance reasons? or not fully spec compliant in node v6.0?