### PR TITLE
Add nyc-mocha-cjs-bridge scenario test

### DIFF
--- a/test/fixture/scenario/nyc-mocha-cjs-bridge/add.js
+++ b/test/fixture/scenario/nyc-mocha-cjs-bridge/add.js
@@ -1,0 +1,1 @@
+export default (a, b) => a + b

--- a/test/fixture/scenario/nyc-mocha-cjs-bridge/cwd.js
+++ b/test/fixture/scenario/nyc-mocha-cjs-bridge/cwd.js
@@ -1,0 +1,3 @@
+"use strict"
+
+process.chdir(__dirname)

--- a/test/fixture/scenario/nyc-mocha-cjs-bridge/require-add.js
+++ b/test/fixture/scenario/nyc-mocha-cjs-bridge/require-add.js
@@ -1,0 +1,5 @@
+"use strict"
+
+require = require("../../../../")(module)
+const add = require("./add").default
+module.exports = add

--- a/test/fixture/scenario/nyc-mocha-cjs-bridge/test.js
+++ b/test/fixture/scenario/nyc-mocha-cjs-bridge/test.js
@@ -1,0 +1,4 @@
+import assert from "assert"
+import add from "./require-add"
+
+assert(add(1, 2), 3)

--- a/test/scenario-tests.mjs
+++ b/test/scenario-tests.mjs
@@ -47,6 +47,19 @@ describe("scenarios", function () {
     , Promise.resolve())
   )
 
+  it("should work with nyc, mocha, and cjs bridge", () => {
+    const dirPath = path.resolve(testPath, "fixture/scenario/nyc-mocha-cjs-bridge")
+    const cwdPath = path.resolve(dirPath, "cwd.js")
+    const mochaPattern = path.resolve(dirPath, "test")
+
+    return exec("nyc", [
+      "--cwd", dirPath,
+      "-i", cwdPath,
+      "-i", pkgPath,
+      "mocha", mochaPattern
+    ], envAuto)
+  })
+
   it("should work with esmod-pmb", () =>
     exec(nodePath, [path.resolve(testPath, "fixture/scenario/esmod-pmb/test.node.js")])
   )


### PR DESCRIPTION
- [x] Adds scenario coverage for issue #325 

I branched this from 3.0.7 (d5cf035) just prior to the fix, and it consistently fails every time.  Merging it onto master it passes every time.  Without `nyc` the test was flaky.  I named the scenario `nyc-mocha-cjs-bridge`.