### PR TITLE
Clarify docs further as to why index.js is needed before main.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ There are two ways to enable `esm`.
 
 1. Enable `esm` for packages:
 
+   The first file used as your entrypoint must `require` ESM using `require("esm")`, but then any
+   of your code imported from then on down can use any import/export style supported by ESM.
+
     **index.js**
     ```js
     // Set options as a parameter, environment variable, or rc file.
@@ -28,8 +31,12 @@ There are two ways to enable `esm`.
     ```
     **main.js**
     ```js
-    // Put ESM code here.
-    export {}
+    // Any import/export style is now supported in your code
+    import {...} from '...'
+    const some_import = require(...)
+    ...
+
+    export {...}
     ```
     :bulb: This is automagically done by [`create-esm`](https://github.com/standard-things/create-esm).
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ There are two ways to enable `esm`.
 
     export {...}
     ```
-    :bulb: This is automagically done by [`create-esm`](https://github.com/standard-things/create-esm).
+    :bulb: A working `index.js` is automagically created if you use [`create-esm`](https://github.com/standard-things/create-esm).
 
 2. Enable `esm` for local runs:
 


### PR DESCRIPTION
This is a follow-up to https://github.com/standard-things/esm/issues/358.

My primary misconception was actually that I didn't realize why both `index.js` and `main.js` were needed.  That's why I was confused as to why only `require` was used in `index.js` but yet somehow `import` and `export` were also supported.

Now I realize that `index.js` serves just to enable ESM mode, and all files imported from there on down now support any import/export style.

The `index`/`main` two-hop system is obvious and clean once I understood why it was being used, but this line in the docs just serves to make it clearer for people who just arrived on the readme with no prior knowledge of the library.