### PR TITLE
adding nodemon to tips

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,8 @@ Tips
   [`nyc`](https://github.com/istanbuljs/nyc#require-additional-modules),
   [`qunit`](https://github.com/qunitjs/qunit/releases/tag/2.6.0),
   [`tape`](https://github.com/substack/tape#preloading-modules),
-  [`ts-node`](https://github.com/TypeStrong/ts-node#cli-options), and
+  [`ts-node`](https://github.com/TypeStrong/ts-node#cli-options),
+  [`nodemon`](https://github.com/remy/nodemon), and
   [`webpack`](https://webpack.js.org/api/cli/#config-options)
 * Load `esm` with the `--node-arg=-r --node-arg=esm` option of
   [`node-tap`](http://www.node-tap.org/cli/)


### PR DESCRIPTION
using **nodemon** since I started using [std/]esm. it's working great together, even with babel-register. ideal for local development.

unfortunately I couldn't find any links or references regarding flags (other than --inspect), but I suppose it does a pass through with known node flags.

usage:
```
nodemon -r esm index.js
```
or:
```
nodemon -r esm -r @babel/register index.js
```
```