### PR TITLE
Add prepare script so esm can be installed from GitHub

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "scripts": {
     "precommit": "npm run lint",
     "prelint": "npm run pretest",
+    "prepare": "npm run build:prod",
     "prepub": "npm run test:prod && npm run build:prod",
     "pretest": "npm run build -- --test",
     "pretest:prod": "npm run build:prod -- --test",


### PR DESCRIPTION
The prepare script is run when esm is installed as a GitHub dependency, and when running `npm install` in a local clone.

This way, `npm install standard-things/esm` will automatically compile the `esm/loader` file, making it easier to try bugfixes before esm is released.