### PR TITLE
kill hanging pm2 process after test run

### DIFF
--- a/test/scenario-tests.mjs
+++ b/test/scenario-tests.mjs
@@ -334,15 +334,24 @@ describe("scenarios", function () {
       })
     }
 
+    function cleanup() {
+      return exec("pm2", ["kill"])
+    }
+
     return Promise
       .resolve()
-      .then(() => exec("pm2", ["kill"]))
+      .then(cleanup)
       .then(() => trash(logsPath))
       .then(() => exec("pm2", pm2Args))
       .then(() => waitForLogs())
       .then(({ stderr, stdout }) => {
         assert.strictEqual(stderr, "")
         assert.ok(stdout.includes("pm2:true"))
+      })
+      .then(cleanup)
+      .catch((e) => {
+        cleanup()
+        throw e
       })
   })
 })


### PR DESCRIPTION
after each test run I had some hanging pm2 processes.

if I run it 5 times, I had 5 ghost processes:

<img width="541" alt="pm2-process" src="https://user-images.githubusercontent.com/2903325/43168395-1b05fdd4-8f6b-11e8-88a6-f44a303f62a5.png">

this PR should take care of it.

unfortunately _Promise.prototype.finally_ isn't available on all versions of node, it'll cleanup for a successful and unsuccessful run (and re-throws, if there was an error)

since we're not testing pm2 kill, trash etc. I wonder if we should rather use [before and after hooks](https://mochajs.org/#hooks). I think that's cleaner and might also be beneficial for other tests. What do you think?