### PR TITLE
add uuid scenario test

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "typescript": "^2.9.2",
     "uglify-es": "^3.3.10",
     "uglifyjs-webpack-plugin": "^1.2.7",
+    "uuid": "^3.3.2",
     "webpack": "^4.16.4",
     "webpack-bundle-analyzer": "^2.13.1",
     "webpack-cli": "^3.1.0",

--- a/test/fixture/scenario/uuid/index.js
+++ b/test/fixture/scenario/uuid/index.js
@@ -1,0 +1,4 @@
+"use strict"
+
+require = require("../../../../")(module)
+require("./main.js")

--- a/test/fixture/scenario/uuid/main.js
+++ b/test/fixture/scenario/uuid/main.js
@@ -1,0 +1,6 @@
+import uuidv4 from "uuid/v4"
+import { log } from "console"
+
+uuidv4()
+
+log("uuid:true")

--- a/test/scenario-tests.mjs
+++ b/test/scenario-tests.mjs
@@ -88,7 +88,7 @@ describe("scenario tests", function () {
   )
 
   it("should work with uuid", () =>
-    exec(nodePath, [path.resolve(testPath, "fixture/scenario/uuid-test")])
+    exec(nodePath, [path.resolve(testPath, "fixture/scenario/uuid")])
       .then(({ stdout }) => assert.ok(stdout.includes("uuid:true")))
   )
 

--- a/test/scenario-tests.mjs
+++ b/test/scenario-tests.mjs
@@ -87,6 +87,11 @@ describe("scenario tests", function () {
       .then(({ stdout }) => assert.ok(stdout.includes("express:true")))
   )
 
+  it("should work with uuid", () =>
+    exec(nodePath, [path.resolve(testPath, "fixture/scenario/uuid-test")])
+      .then(({ stdout }) => assert.ok(stdout.includes("uuid:true")))
+  )
+
   it("should work with global-prefix", () =>
     exec(nodePath, [path.resolve(testPath, "fixture/scenario/global-prefix")])
       .then(({ stdout }) => assert.ok(stdout.includes("global-prefix:true")))


### PR DESCRIPTION
test for https://github.com/standard-things/esm/issues/541

shouldn't we rather test a `minified` build on the build machines if minification can have implications?

also, it would be good to see this fail somewhere first. meaning a branch with the v3.0.73 commit build running the minified version against node v8 -- or you could run it locally?

btw, since I can't repro locally (running node v10+), what caused the illegal invocation?
wouldn't it be better to have a real test case as supposed to a scenario test? if the `uuid` module ever changes their implementation, we would never know ...