### PR TITLE
WIP: initial attempt to run 'esm' against tc39/test262

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@
 /test/fixture/main-hook/symlink/symlink.js
 /test/fixture/main-hook/symlink/symlink.mjs
 /test/fixture/scenario/ava-nyc-tsc/*.js
+
+/test/vendor/test262/.repo
+/test/vendor/test262/.js-tests
+/test/vendor/test262/.mjs-tests

--- a/package-lock.json
+++ b/package-lock.json
@@ -16747,6 +16747,16 @@
         }
       }
     },
+    "test262-parser": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/test262-parser/-/test262-parser-2.0.7.tgz",
+      "integrity": "sha1-cztGv3dZ50fq40tbFNajyNIIKt0=",
+      "dev": true,
+      "requires": {
+        "js-yaml": "^3.2.1",
+        "through": "^2.3.4"
+      }
+    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "sleep": "^5.2.3",
     "sqreen": "^1.22.0",
     "strip-ansi": "^4.0.0",
+    "test262-parser": "^2.0.7",
     "trash": "^4.3.0",
     "ts-node": "^7.0.1",
     "typescript": "^3.0.1",

--- a/script/test.js
+++ b/script/test.js
@@ -6,6 +6,7 @@ const ignorePaths = require("./ignore-paths.js")
 const path = require("path")
 const trash = require("./trash.js")
 const uglify = require("uglify-es").minify
+const bootstrapTest262 = require("./test262/bootstrap.js")
 
 const argv = require("yargs")
   .boolean("prod")
@@ -114,5 +115,6 @@ Promise
     cleanRepo(),
     setupNode()
   ])
+  .then(bootstrapTest262)
   .then(() => runTests())
   .then(() => runTests(true))

--- a/script/test262/bootstrap.js
+++ b/script/test262/bootstrap.js
@@ -1,0 +1,26 @@
+"use strict"
+
+const { resolve } = require("path")
+const clone = require("./clone.js")
+const copy = require("./copy.js")
+const renameFileExtension = require("./file-extension.js")
+
+const rootPath = resolve(".")
+const mjsTestPath = resolve(rootPath, "test/vendor/test262/.mjs-tests")
+
+function bootstrap() {
+  return (
+    clone()
+      .then(copy)
+      // TODO remove:
+      // temporary measure and can be safily removed once
+      // the `dynamic import` test PR is merged into test262
+      // -- BEGIN
+      .then(clone.dynamicImport)
+      .then(copy.dynamicImport)
+      // -- END
+      .then(() => renameFileExtension(mjsTestPath, "js", "mjs"))
+  )
+}
+
+module.exports = bootstrap

--- a/script/test262/clone.js
+++ b/script/test262/clone.js
@@ -1,0 +1,51 @@
+"use strict"
+
+const { resolve } = require("path")
+const execa = require("execa")
+const { removeSync } = require("fs-extra")
+
+const rootPath = resolve(".")
+const test262Path = resolve(rootPath, "test/vendor/test262")
+const test262RepoPath = resolve(test262Path, ".repo-clone")
+// const test262RepoGitPath = resolve(test262RepoPath, ".git")
+
+function run(cwd, file, args) {
+  return execa(file, args, {
+    cwd,
+    reject: false
+  })
+}
+
+function clone() {
+  removeSync(test262RepoPath)
+
+  return run(test262Path, "git", ["--version"]).then(() =>
+    run(test262Path, "git", [
+      "clone",
+      "--depth",
+      "1",
+      "https://github.com/tc39/test262.git",
+      ".repo-clone"
+    ])
+  )
+}
+
+// TODO remove:
+// this is just a temporary measure and can be safily removed once
+// the `dynamic import` test PR is merged into test262
+// -- BEGIN
+clone.dynamicImport = function () {
+  return run(test262RepoPath, "git", [
+    "fetch",
+    "origin",
+    "--depth",
+    "1",
+    "pull/1588/head:dynamic-import"
+  ]).then(() => run(test262RepoPath, "git", ["checkout", "dynamic-import"]))
+  // .then(() =>
+  //   trash(test262RepoGitPath)
+  // )
+  // -- END
+}
+
+module.exports = clone

--- a/script/test262/copy.js
+++ b/script/test262/copy.js
@@ -1,0 +1,48 @@
+"use strict"
+
+const { resolve } = require("path")
+const { copySync, removeSync } = require("fs-extra")
+
+const rootPath = resolve(".")
+const test262RepoPath = resolve(rootPath, "test/vendor/test262/.repo-clone")
+const jsTestPath = resolve(rootPath, "test/vendor/test262/.js-tests")
+const mjsTestPath = resolve(rootPath, "test/vendor/test262/.mjs-tests")
+
+const testDirs = [
+  "test/language/export",
+  "test/language/import",
+  "test/language/module-code",
+  "harness"
+]
+
+function copyTests() {
+  removeSync(jsTestPath)
+  removeSync(mjsTestPath)
+
+  testDirs.map((testDir) => {
+    copySync(resolve(test262RepoPath, testDir), resolve(jsTestPath, testDir))
+    copySync(resolve(test262RepoPath, testDir), resolve(mjsTestPath, testDir))
+  })
+}
+
+// TODO remove:
+// temporary measure and can be safily removed once
+// the `dynamic import` test PR is merged into test262
+// -- BEGIN
+const testDirsDynamicImport = ["test/language/module-code/dynamic-import"]
+
+copyTests.dynamicImport = function () {
+  testDirsDynamicImport.map((testDirDynamicImport) => {
+    copySync(
+      resolve(test262RepoPath, testDirDynamicImport),
+      resolve(jsTestPath, testDirDynamicImport)
+    )
+    copySync(
+      resolve(test262RepoPath, testDirDynamicImport),
+      resolve(mjsTestPath, testDirDynamicImport)
+    )
+  })
+}
+// -- END
+
+module.exports = copyTests

--- a/script/test262/file-extension.js
+++ b/script/test262/file-extension.js
@@ -1,0 +1,33 @@
+const { sep } = require("path")
+const { readFileSync, renameSync, writeFileSync } = require("fs-extra")
+const globby = require("globby")
+
+function renameFileExtension(test262Path, fromExt, toExt) {
+  const test262Files = globby.sync(
+    [
+      `test/language/export/**/*.${fromExt}`,
+      `test/language/import/**/*.${fromExt}`,
+      `test/language/module-code/**/*.${fromExt}`
+    ],
+    {
+      absolute: true,
+      cwd: test262Path,
+      // https://github.com/sindresorhus/globby/issues/38
+      transform: (entry) => (sep === "\\" ? entry.replace(/\//g, "\\") : entry)
+    }
+  )
+
+  test262Files.forEach((file) => {
+    const raw = readFileSync(file, "utf-8")
+
+    const content = raw.replace(new RegExp("." + fromExt, "g"), "." + toExt)
+
+    writeFileSync(file, content)
+  })
+
+  test262Files.forEach((file) =>
+    renameSync(file, file.replace("." + fromExt, "." + toExt))
+  )
+}
+
+module.exports = renameFileExtension

--- a/script/test262/files.js
+++ b/script/test262/files.js
@@ -1,0 +1,27 @@
+"use strict"
+
+const globby = require("globby")
+const { resolve } = require("path")
+
+const testPath = resolve(__dirname, "../../test/vendor/test262/.test")
+
+exports.getTestFiles = function getTestFiles() {
+  return globby(
+    [
+      "test/language/export/**/*.js",
+      "test/language/import/**/*.js",
+      "test/language/module-code/**/*.js"
+    ],
+    {
+      absolute: true,
+      cwd: testPath
+    }
+  )
+}
+
+exports.getHarnessFiles = function getHarnessFiles() {
+  return globby(["harness/*.js"], {
+    absolute: true,
+    cwd: testPath
+  })
+}

--- a/test/tests.js
+++ b/test/tests.js
@@ -20,6 +20,7 @@ import "./main-hook-tests.mjs"
 import "./require-hook-tests.js"
 import "./repl-hook-tests.mjs"
 import "./scenario-tests.mjs"
+import "./vendor/test262/index.js"
 
 const extensions = Object.assign({}, require.extensions)
 

--- a/test/vendor/test262/context.js
+++ b/test/vendor/test262/context.js
@@ -1,0 +1,35 @@
+import { createContext, Script } from "vm"
+import { basename, resolve } from "path"
+import test262Parser from "test262-parser"
+import fs from "fs-extra"
+import globby from "globby"
+import { stdout } from "process"
+
+// TODO:
+const testPath = resolve("../test/vendor/test262/.js-tests")
+
+const harnessFiles = [
+  "assert.js",
+  "sta.js",
+  "doneprintHandle.js",
+  "fnGlobalObject.js"
+]
+
+function getHarnessFiles() {
+  return globby.sync(["harness/*.js"], {
+    absolute: true,
+    cwd: testPath
+  })
+}
+
+const sandbox = createContext(global)
+
+export default function harnessContext() {
+  getHarnessFiles()
+    .filter((file) => harnessFiles.includes(basename(file)))
+    .map((filename) => fs.readFileSync(filename, "utf-8"))
+    .forEach((rawHarness) => {
+      const { contents } = test262Parser.parseFile(rawHarness)
+      new Script(contents).runInContext(sandbox)
+    })
+}

--- a/test/vendor/test262/index.js
+++ b/test/vendor/test262/index.js
@@ -1,0 +1,193 @@
+import SemVer from "semver"
+import assert from "assert"
+import execa from "execa"
+import globby from "globby"
+import { basename, resolve, sep } from "path"
+import fs from "fs-extra"
+import test262Parser from "test262-parser"
+
+const { execArgv, execPath, versions } = process
+
+const testPath = resolve(".")
+const test262Path = resolve(testPath, "vendor/test262/.js-tests")
+
+let nodeVersion = Reflect.has(process.versions, "v8") ? SemVer.major(process.version) : ""
+
+if (execArgv.includes("--harmony")) {
+  nodeVersion = "harmony"
+} else if (Reflect.has(versions, "chakracore")) {
+  nodeVersion = "chakra"
+}
+
+function node(args, env) {
+  return execa(execPath, args, {
+    cwd: testPath,
+    env,
+    reject: false
+  })
+}
+
+const nodeArgs = []
+
+if (nodeVersion === "harmony") {
+  nodeArgs.push("--harmony")
+}
+
+function runEsm(filename, env, args) {
+  return node([...nodeArgs, "-r", "esm", filename, ...args], env)
+}
+
+function runNodeModFlag(filename, args) {
+  return node([
+    ...nodeArgs,
+    "--experimental-modules",
+    "--no-warnings",
+    filename,
+    ...args
+  ])
+}
+
+const test262Tests = globby.sync(
+  [
+    "test/language/export/**/*.js",
+    "test/language/import/**/*.js",
+    "test/language/module-code/**/*.js",
+    "!**/*_FIXTURE.js"
+  ],
+  {
+    absolute: true,
+    cwd: test262Path,
+    // https://github.com/sindresorhus/globby/issues/38
+    transform: (entry) => (sep === "\\" ? entry.replace(/\//g, "\\") : entry)
+  }
+)
+
+const skiplist = new Map()
+
+function parseTest(filepath) {
+  const rawTest = fs.readFileSync(filepath, "utf-8")
+
+  const {
+    attrs: { description, negative, flags }
+  } = test262Parser.parseFile(rawTest)
+
+  return {
+    description,
+    isAsync: flags && flags.async,
+    errorType: negative && negative.type
+  }
+}
+
+function loadSkiplist() {
+  const content = fs.readFileSync(resolve(test262Path, "../skiplist"), "utf-8")
+
+  content
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line !== "")
+    .reduce((comment, line) => {
+      if (line.startsWith("#")) {
+        if (comment) {
+          throw new Error(
+            `The skiplist contains multiple comments in consecutive rows: "${comment}" and "${line}". This is not allowed.`
+          )
+        }
+
+        return line
+      }
+
+      if (! comment) {
+        throw new Error(
+          `A reason for skipping is required! None was given for: "${line}".`
+        )
+      }
+
+      const skiplistFlags = comment.match(/@[a-z0-9-]*/g) || []
+
+      const fullPath = resolve(test262Path, line)
+
+      if (isSkiplisted(fullPath)) {
+        throw new Error(`Same entry in skiplist already exists for: "${line}".`)
+      }
+
+      comment = comment.slice(1).trimLeft()
+
+      skiplist.set(fullPath, {
+        comment,
+        skiplistFlags
+      })
+
+      return null
+    }, null)
+}
+
+loadSkiplist()
+
+function isSkiplisted(test) {
+  const item = skiplist.get(test)
+
+  if (! item) {
+    return false
+  }
+
+  if (item.skiplistFlags.includes(`@${nodeVersion}`) || item.skiplistFlags.length === 0) {
+    return true
+  }
+
+  return false
+}
+
+function skiplistReason(test) {
+  return skiplist.get(test).comment
+}
+
+const test262Error = "Test262: This statement should not be evaluated."
+
+// const ESM_OPTIONS = JSON.stringify({ /* mode: "strict" */ })
+const ESM_OPTIONS = JSON.stringify({ mode: "all", cjs: false })
+
+describe.only("test262 module tests", function () {
+  this.timeout(0)
+
+  test262Tests.forEach(function (test262TestPath, index) {
+    const { description } = parseTest(test262TestPath)
+
+    const skip = isSkiplisted(test262TestPath)
+
+    const skipReason = skip ? `| ${skiplistReason(test262TestPath)}` : ""
+
+    const testfunc = skip ? it.skip : it
+
+    const filename = basename(test262TestPath)
+
+    testfunc(
+      `[${index}] ${description} (${filename}) ${skipReason}`,
+      function () {
+        const { isAsync, errorType } = parseTest(test262TestPath)
+
+        // return runMain(resolve(test262Path, "../wrapper.mjs"), [test262TestPath, isAsync])
+        return runEsm(resolve(test262Path, "../wrapper.js"), { ESM_OPTIONS }, [
+          test262TestPath,
+          isAsync
+        ]).then((out) => {
+          const { stdout, stderr } = out
+
+          // console.log(stdout, stderr)
+
+          if (stdout) {
+            const { name } = JSON.parse(stdout)
+
+            // possible known "supported" test262 constructors:
+            // SyntaxError, Test262Error, ReferenceError, TypeError
+            assert.strictEqual(errorType, name)
+          }
+
+          if (stderr) {
+            console.log("stderr ==>", stderr)
+            assert.fail("possible test262 Error")
+          }
+        })
+      }
+    )
+  })
+})

--- a/test/vendor/test262/skiplist
+++ b/test/vendor/test262/skiplist
@@ -1,0 +1,357 @@
+# NOT YET SUPPORTED 🚧  (export * as ns from "mod")
+test/language/module-code/eval-rqstd-once.js
+
+# NOT YET SUPPORTED 🚧  (export * as ns from "mod")
+test/language/module-code/eval-rqstd-order.js
+
+# NOT YET SUPPORTED 🚧  (export * as ns from "mod")
+test/language/module-code/eval-self-once.js
+
+# NOT YET SUPPORTED 🚧  (export * as ns from "mod")
+test/language/module-code/instn-once.js
+
+# NOT YET SUPPORTED 🚧  (export * as ns from "mod")
+test/language/module-code/instn-star-as-props-dflt-skip.js
+
+# NOT YET SUPPORTED 🚧  (export * as ns from "mod")
+test/language/module-code/instn-star-props-nrml.js
+
+# NOT YET SUPPORTED 🚧  (export * as ns from "mod")
+test/language/module-code/namespace/internals/get-nested-namespace-dflt-skip.js
+
+# NOT YET SUPPORTED 🚧  (export * as ns from "mod")
+test/language/module-code/namespace/internals/get-nested-namespace-props-nrml.js
+
+
+
+# CONFIRMED BUG 🐛  (instantiation phase)
+test/language/module-code/instn-iee-bndng-fun.js
+
+# CONFIRMED BUG 🐛  (instantiation phase)
+test/language/module-code/instn-iee-bndng-gen.js
+
+# CONFIRMED BUG 🐛  (instantiation phase)
+test/language/module-code/instn-iee-bndng-var.js
+
+# CONFIRMED BUG 🐛  (instantiation phase)
+test/language/module-code/instn-iee-star-cycle.js
+
+# CONFIRMED BUG 🐛  (instantiation phase)
+test/language/module-code/instn-iee-trlng-comma.js
+
+# CONFIRMED BUG 🐛  (instantiation phase)
+test/language/module-code/instn-named-bndng-dflt-named.js
+
+# CONFIRMED BUG 🐛  (instantiation phase)
+test/language/module-code/instn-named-bndng-trlng-comma.js
+
+# CONFIRMED BUG 🐛  (instantiation phase)
+test/language/module-code/instn-named-bndng-var.js
+
+
+
+# CONFIRMED BUG 🐛  (cycle import)
+test/language/module-code/instn-iee-iee-cycle.js
+
+# NEEDS INVESTIGATION 🐛  (cycle import)
+test/language/module-code/instn-named-iee-cycle.js
+
+# NEEDS INVESTIGATION 🐛  (cycle import)
+test/language/module-code/instn-star-iee-cycle.js
+
+
+
+# PRIVATE CLASS FIELD 🔥  @6 @8 @10 @chakra
+test/language/module-code/privatename-not-valid-earlyerr-module-1.js
+
+# PRIVATE CLASS FIELD 🔥  @6 @8 @10 @chakra
+test/language/module-code/privatename-not-valid-earlyerr-module-2.js
+
+# PRIVATE CLASS FIELD 🔥  @6 @8 @10 @chakra
+test/language/module-code/privatename-not-valid-earlyerr-module-3.js
+
+# PRIVATE CLASS FIELD 🔥  @6 @8 @10 @chakra
+test/language/module-code/privatename-not-valid-earlyerr-module-4.js
+
+# PRIVATE CLASS FIELD 🔥  @6 @8 @10 @chakra
+test/language/module-code/privatename-not-valid-earlyerr-module-5.js
+
+# PRIVATE CLASS FIELD 🔥  @6 @8 @10 @chakra
+test/language/module-code/privatename-not-valid-earlyerr-module-6.js
+
+# PRIVATE CLASS FIELD 🔥  @6 @8 @10 @chakra
+test/language/module-code/privatename-not-valid-earlyerr-module-7.js
+
+# PRIVATE CLASS FIELD 🔥  @6 @8 @10 @chakra
+test/language/module-code/privatename-not-valid-earlyerr-module-8.js
+
+# PRIVATE CLASS FIELD 🔥  @6 @8 @10 @chakra
+test/language/module-code/privatename-valid-no-earlyerr.js
+
+
+
+# NEEDS INVESTIGATION 👀
+test/language/module-code/namespace/internals/delete-exported-init.js
+
+# NEEDS INVESTIGATION 👀
+test/language/module-code/namespace/internals/get-own-property-str-found-init.js
+
+# NEEDS INVESTIGATION 👀
+test/language/module-code/namespace/internals/get-str-found-init.js
+
+# NEEDS INVESTIGATION 👀
+test/language/module-code/namespace/internals/get-str-initialize.js
+
+# NEEDS INVESTIGATION 👀
+test/language/module-code/namespace/internals/get-str-update.js
+
+
+
+# NEEDS INVESTIGATION 👀  @6
+test/language/module-code/eval-export-dflt-cls-anon.js
+
+# NEEDS INVESTIGATION 👀  @6
+test/language/module-code/eval-export-dflt-expr-cls-anon.js
+
+# NEEDS INVESTIGATION 👀  @6
+test/language/module-code/eval-export-dflt-expr-fn-anon.js
+
+# NEEDS INVESTIGATION 👀  @6
+test/language/module-code/eval-export-dflt-expr-gen-anon.js
+
+# NEEDS INVESTIGATION 👀  @6 @chakra
+test/language/module-code/namespace/internals/enumerate-binding-uninit.js
+
+# NEEDS INVESTIGATION 👀  @6 @chakra
+test/language/module-code/namespace/internals/object-keys-binding-uninit.js
+
+
+
+# DYNAMIC IMPORT ❌  (test wrong)
+test/language/module-code/dynamic-import/catch-nested-arrow-import-catch-instn-iee-err-not-found.js
+
+# DYNAMIC IMPORT ❌  (test wrong)
+test/language/module-code/dynamic-import/catch-nested-async-function-await-instn-iee-err-not-found.js
+
+# DYNAMIC IMPORT ❌  (test wrong)
+test/language/module-code/dynamic-import/catch-nested-async-function-instn-iee-err-not-found.js
+
+# DYNAMIC IMPORT ❌  (test wrong)
+test/language/module-code/dynamic-import/catch-nested-async-function-return-await-instn-iee-err-not-found.js
+
+# DYNAMIC IMPORT ❌  (test wrong)
+test/language/module-code/dynamic-import/catch-nested-block-import-catch-instn-iee-err-not-found.js
+
+# DYNAMIC IMPORT ❌  (test wrong)
+test/language/module-code/dynamic-import/catch-nested-block-labeled-instn-iee-err-not-found.js
+
+# DYNAMIC IMPORT ❌  (test wrong)
+test/language/module-code/dynamic-import/catch-nested-do-import-catch-instn-iee-err-not-found.js
+
+# DYNAMIC IMPORT ❌  (test wrong)
+test/language/module-code/dynamic-import/catch-nested-do-while-instn-iee-err-not-found.js
+
+# DYNAMIC IMPORT ❌  (test wrong)
+test/language/module-code/dynamic-import/catch-nested-else-import-catch-instn-iee-err-not-found.js
+
+# DYNAMIC IMPORT ❌  (test wrong)
+test/language/module-code/dynamic-import/catch-nested-function-import-catch-instn-iee-err-not-found.js
+
+# DYNAMIC IMPORT ❌  (test wrong)
+test/language/module-code/dynamic-import/catch-nested-if-import-catch-instn-iee-err-not-found.js
+
+# DYNAMIC IMPORT ❌  (test wrong)
+test/language/module-code/dynamic-import/catch-nested-labeled-block-import-catch-instn-iee-err-not-found.js
+
+# DYNAMIC IMPORT ❌  (test wrong)
+test/language/module-code/dynamic-import/catch-nested-while-import-catch-instn-iee-err-not-found.js
+
+# DYNAMIC IMPORT ❌  (test wrong)
+test/language/module-code/dynamic-import/catch-top-level-import-catch-instn-iee-err-not-found.js
+
+# DYNAMIC IMPORT ❌  (incomplete test)
+test/language/module-code/dynamic-import/nested-if-braceless-eval-gtbdng-indirect-update-as.js
+
+# DYNAMIC IMPORT ❌  (incomplete test)
+test/language/module-code/dynamic-import/nested-if-braceless-eval-gtbdng-indirect-update-dflt.js
+
+# DYNAMIC IMPORT ❌  (incomplete test)
+test/language/module-code/dynamic-import/nested-if-braceless-eval-gtbndng-indirect-update.js
+
+# DYNAMIC IMPORT ❌  (incomplete test)
+test/language/module-code/dynamic-import/nested-if-braceless-returns-promise.js
+
+# DYNAMIC IMPORT ❌  (incomplete test: empty import)
+test/language/module-code/dynamic-import/syntax-nested-block-empty-str-arg.js
+
+# DYNAMIC IMPORT ❌  (incomplete test: empty import)
+test/language/module-code/dynamic-import/syntax-nested-block-labeled-empty-str-arg.js
+
+# DYNAMIC IMPORT ❌  (incomplete test: empty import)
+test/language/module-code/dynamic-import/syntax-nested-do-empty-str-arg.js
+
+# DYNAMIC IMPORT ❌  (incomplete test: empty import)
+test/language/module-code/dynamic-import/syntax-nested-do-while-empty-str-arg.js
+
+# DYNAMIC IMPORT ❌  (incomplete test: empty import)
+test/language/module-code/dynamic-import/syntax-nested-else-braceless-empty-str-arg.js
+
+# DYNAMIC IMPORT ❌  (incomplete test: empty import)
+test/language/module-code/dynamic-import/syntax-nested-else-empty-str-arg.js
+
+# DYNAMIC IMPORT ❌  (incomplete test: empty import)
+test/language/module-code/dynamic-import/syntax-nested-if-braceless-empty-str-arg.js
+
+# DYNAMIC IMPORT ❌  (incomplete test: empty import)
+test/language/module-code/dynamic-import/syntax-nested-if-empty-str-arg.js
+
+# DYNAMIC IMPORT ❌  (incomplete test: empty import)
+test/language/module-code/dynamic-import/syntax-nested-labeled-block-empty-str-arg.js
+
+# DYNAMIC IMPORT ❌  (incomplete test: empty import)
+test/language/module-code/dynamic-import/syntax-nested-while-empty-str-arg.js
+
+# DYNAMIC IMPORT ❌  (incomplete test: empty import)
+test/language/module-code/dynamic-import/syntax-top-level-empty-str-arg.js
+
+
+
+# ASYNC FUNCTION @6
+test/language/module-code/dynamic-import/catch-nested-async-function-await-eval-rqstd-abrupt-typeerror.js
+
+# ASYNC FUNCTION @6
+test/language/module-code/dynamic-import/catch-nested-async-function-await-eval-rqstd-abrupt-urierror.js
+
+# ASYNC FUNCTION @6
+test/language/module-code/dynamic-import/catch-nested-async-function-await-instn-iee-err-ambiguous-import.js
+
+# ASYNC FUNCTION @6
+test/language/module-code/dynamic-import/catch-nested-async-function-await-instn-iee-err-circular.js
+
+# ASYNC FUNCTION @6
+test/language/module-code/dynamic-import/catch-nested-async-function-eval-rqstd-abrupt-typeerror.js
+
+# ASYNC FUNCTION @6
+test/language/module-code/dynamic-import/catch-nested-async-function-eval-rqstd-abrupt-urierror.js
+
+# ASYNC FUNCTION @6
+test/language/module-code/dynamic-import/catch-nested-async-function-instn-iee-err-ambiguous-import.js
+
+# ASYNC FUNCTION @6
+test/language/module-code/dynamic-import/catch-nested-async-function-instn-iee-err-circular.js
+
+# ASYNC FUNCTION @6
+test/language/module-code/dynamic-import/catch-nested-async-function-return-await-eval-rqstd-abrupt-typeerror.js
+
+# ASYNC FUNCTION @6
+test/language/module-code/dynamic-import/catch-nested-async-function-return-await-eval-rqstd-abrupt-urierror.js
+
+# ASYNC FUNCTION @6
+test/language/module-code/dynamic-import/catch-nested-async-function-return-await-instn-iee-err-ambiguous-import.js
+
+# ASYNC FUNCTION @6
+test/language/module-code/dynamic-import/catch-nested-async-function-return-await-instn-iee-err-circular.js
+
+# ASYNC FUNCTION @6
+test/language/module-code/dynamic-import/nested-async-function-await-eval-gtbdng-indirect-update-as.js
+
+# ASYNC FUNCTION @6
+test/language/module-code/dynamic-import/nested-async-function-await-eval-gtbdng-indirect-update-dflt.js
+
+# ASYNC FUNCTION @6
+test/language/module-code/dynamic-import/nested-async-function-await-eval-gtbndng-indirect-update.js
+
+# ASYNC FUNCTION @6
+test/language/module-code/dynamic-import/nested-async-function-await-returns-promise.js
+
+# ASYNC FUNCTION @6
+test/language/module-code/dynamic-import/nested-async-function-eval-gtbdng-indirect-update-as.js
+
+# ASYNC FUNCTION @6
+test/language/module-code/dynamic-import/nested-async-function-eval-gtbdng-indirect-update-dflt.js
+
+# ASYNC FUNCTION @6
+test/language/module-code/dynamic-import/nested-async-function-eval-gtbndng-indirect-update.js
+
+# ASYNC FUNCTION @6
+test/language/module-code/dynamic-import/nested-async-function-return-await-eval-gtbdng-indirect-update-as.js
+
+# ASYNC FUNCTION @6
+test/language/module-code/dynamic-import/nested-async-function-return-await-eval-gtbdng-indirect-update-dflt.js
+
+# ASYNC FUNCTION @6
+test/language/module-code/dynamic-import/nested-async-function-return-await-eval-gtbndng-indirect-update.js
+
+# ASYNC FUNCTION @6
+test/language/module-code/dynamic-import/nested-async-function-return-await-returns-promise.js
+
+# ASYNC FUNCTION @6
+test/language/module-code/dynamic-import/nested-async-function-returns-promise.js
+
+
+
+# CHAKRA ONLY ⚠️  - NEEDS INVESTIGATION 👀 @chakra
+test/language/module-code/instn-iee-bndng-cls.js
+
+# CHAKRA ONLY ⚠️  - NEEDS INVESTIGATION 👀 @chakra
+test/language/module-code/instn-iee-bndng-const.js
+
+# CHAKRA ONLY ⚠️  - NEEDS INVESTIGATION 👀 @chakra
+test/language/module-code/instn-iee-bndng-let.js
+
+# CHAKRA ONLY ⚠️  - NEEDS INVESTIGATION 👀 @chakra
+test/language/module-code/instn-named-bndng-cls.js
+
+# CHAKRA ONLY ⚠️  - NEEDS INVESTIGATION 👀 @chakra
+test/language/module-code/instn-named-bndng-const.js
+
+# CHAKRA ONLY ⚠️  - NEEDS INVESTIGATION 👀 @chakra
+test/language/module-code/instn-named-bndng-dflt-cls.js
+
+# CHAKRA ONLY ⚠️  - NEEDS INVESTIGATION 👀 @chakra
+test/language/module-code/instn-named-bndng-dflt-expr.js
+
+# CHAKRA ONLY ⚠️  - NEEDS INVESTIGATION 👀 @chakra
+test/language/module-code/instn-named-bndng-dflt-star.js
+
+# CHAKRA ONLY ⚠️  - NEEDS INVESTIGATION 👀 @chakra
+test/language/module-code/instn-named-bndng-fun.js
+
+# CHAKRA ONLY ⚠️  - NEEDS INVESTIGATION 👀 @chakra
+test/language/module-code/instn-named-bndng-gen.js
+
+# CHAKRA ONLY ⚠️  - NEEDS INVESTIGATION 👀 @chakra
+test/language/module-code/instn-named-bndng-let.js
+
+# CHAKRA ONLY ⚠️  - NEEDS INVESTIGATION 👀 @chakra
+test/language/module-code/instn-star-binding.js
+
+# CHAKRA ONLY ⚠️  - NEEDS INVESTIGATION 👀 @chakra
+test/language/module-code/instn-uniq-env-rec.js
+
+# CHAKRA ONLY ⚠️  - NEEDS INVESTIGATION 👀 @chakra
+test/language/module-code/namespace/internals/define-own-property.js
+
+# CHAKRA ONLY ⚠️  - NEEDS INVESTIGATION 👀 @chakra
+test/language/module-code/namespace/internals/delete-exported-uninit.js
+
+# CHAKRA ONLY ⚠️  - NEEDS INVESTIGATION 👀 @chakra
+test/language/module-code/namespace/internals/delete-non-exported.js
+
+# CHAKRA ONLY ⚠️  - NEEDS INVESTIGATION 👀 @chakra
+test/language/module-code/namespace/internals/get-own-property-str-found-uninit.js
+
+# CHAKRA ONLY ⚠️  - NEEDS INVESTIGATION 👀 @chakra
+test/language/module-code/namespace/internals/get-str-found-uninit.js
+
+# CHAKRA ONLY ⚠️  - NEEDS INVESTIGATION 👀 @chakra
+test/language/module-code/namespace/internals/object-hasOwnProperty-binding-uninit.js
+
+# CHAKRA ONLY ⚠️  - NEEDS INVESTIGATION 👀 @chakra
+test/language/module-code/namespace/internals/object-propertyIsEnumerable-binding-uninit.js
+
+# CHAKRA ONLY ⚠️  - NEEDS INVESTIGATION 👀 @chakra
+test/language/module-code/namespace/internals/set.js
+
+# CHAKRA ONLY ⚠️  - NEEDS INVESTIGATION 👀 @chakra
+test/language/module-code/namespace/internals/set-prototype-of-null.js

--- a/test/vendor/test262/wrapper.js
+++ b/test/vendor/test262/wrapper.js
@@ -1,0 +1,64 @@
+import process from "process"
+import harnessContext from "./context.js"
+
+const { argv, stderr, stdout } = process
+
+const [, , testUrl, isAsync] = argv
+const _isAsync = isAsync === "true"
+
+// attach test262 harness onto global scope
+harnessContext()
+
+let _msg
+
+// global print function expected by test262
+global.print = function print(val) {
+  _msg = val
+}
+
+const MAX_WAIT = 1000
+
+function waitForAsyncTest() {
+  let wait = 0
+
+  return new Promise(function time(res, rej) {
+    if (_msg) {
+      return res()
+    } else if (wait === MAX_WAIT) {
+      return rej("test262: async test timed out.")
+    }
+
+    setTimeout(() => time(res, rej), (wait += 200))
+  })
+}
+
+import(testUrl)
+  .then(() => {
+    if (!_isAsync) {
+      return
+    }
+
+    return waitForAsyncTest().then(() => {
+      if (_msg !== "Test262:AsyncTestComplete") {
+        throw _msg
+      }
+    })
+  })
+  .catch((e) => {
+    const name = typeof e === "string" ? e : e.constructor.name
+
+    const send = JSON.stringify({
+      name,
+      message: typeof e !== "string" && e.message,
+      argv
+    })
+
+    stdout.write(send)
+  })
+  .catch((e) =>
+    stderr.write(
+      `[last resort catch] something happened in the previous catch block: ${
+        e.message
+      }}`
+    )
+  )


### PR DESCRIPTION
**work in progress**

_notes and questions coming soon_

just want to see some runs first :yum:

**update:**

alrighty, cool. looking pretty good so far! 

_btw, the folder structure etc. where test262 is being cloned into and modified to etc. should probably change. also the way the tests are run (right now as part of the whole test suite). we can separate it out and make it a separate run, or a combination thereof..._

couple things I'm noticing which are still to do:
- [x] skiplist not working on Windows
- [x] activate other folders, e.g. `import`, `export`
- [x] fix globbing (missed subfolders)
- [x] make test262 pass on each platform first (use skiplist), then go backwards and unblock
- [x] add --harmony flag for `private class property` on supported platforms only (node v10+ probably)
  ~- [ ] use test262 frontmatter `features` class-fields-private~
- [ ] should we recognize the frontmatter `module`-flag?
  - [ ] investigate: there might be other tests in other folders with that flag
- [x] investigate `node v6.2` failures: probably unsupported features [yep, works on v6.14.3 LTS latest]
- [x] add with esm options: { cjs:false }
- [x] investigate: the `chakracore` run
- [ ] implement flag for ignoring (all or portions) of the skiplist
- [x] fetch `dynamic import` test [branch from PR](https://github.com/tc39/test262/pull/1588)
- [x] run against `--experimental-modules`

_I'll add more later ..._