### PR TITLE
test that console.log works the same as in node [#555]

### DIFF
--- a/test/builtin-modules.js
+++ b/test/builtin-modules.js
@@ -1,0 +1,36 @@
+import assert from "assert"
+import { resolve } from "path"
+import execa from "execa"
+import { execPath } from "process"
+
+const testPath = resolve(".")
+
+function node(args, env) {
+  return execa(execPath, args, {
+    cwd: testPath,
+    env,
+    reject: false
+  })
+}
+
+function runMain(filename, env, arg) {
+  return node(["-r", "../", filename, arg], env)
+}
+
+function runMainPlain(filename) {
+  return node([filename])
+}
+
+describe("test builtin modules", function () {
+  it("console should work the same as in node", function () {
+    const test = resolve(testPath, "fixture/builtin-modules/console")
+
+    return Promise.all([
+      runMainPlain(test),
+      runMain(test)
+    ])
+    .then(([result1, result2]) => {
+      assert.strictEqual(result1.stdout, result2.stdout)
+    })
+  })
+})

--- a/test/builtin-modules.js
+++ b/test/builtin-modules.js
@@ -29,8 +29,8 @@ describe("test builtin modules", function () {
       runMainPlain(test),
       runMain(test)
     ])
-    .then(([result1, result2]) => {
+    .then(([result1, result2]) =>
       assert.strictEqual(result1.stdout, result2.stdout)
-    })
+    )
   })
 })

--- a/test/fixture/builtin-modules/console.js
+++ b/test/fixture/builtin-modules/console.js
@@ -1,0 +1,8 @@
+console.log(
+  new Map([
+    [1,[1,2,3], null, void 0, NaN],
+    [{ test:3, f:"abc"}, 5],
+    [Promise, new Set(["esm", () => 1, class A {}])],
+    [new WeakMap([[{test:1}]]), new WeakSet([() => {}])]
+  ])
+)

--- a/test/tests.js
+++ b/test/tests.js
@@ -17,6 +17,7 @@ import "./cli-hook-tests.mjs"
 import "./main-hook-tests.mjs"
 import "./require-hook-tests.js"
 import "./repl-hook-tests.mjs"
+import "./builtin-modules.js"
 import "./scenario-tests.mjs"
 
 const extensions = Object.assign({}, require.extensions)


### PR DESCRIPTION
not sure how stupid this test is, or if it's even necessary, or if there's a better way:
but hey, at least it fails before [this commit](https://github.com/standard-things/esm/commit/c23a6d5dec6251ad8a7ddb24c23cb99ea03a9067), so there won't be a regression.

@jdalton created under a new umbrella, but we can move it elsewhere.