### PR TITLE
Use readFileSync from fs to play nicer with tink

### DIFF
--- a/esm.js
+++ b/esm.js
@@ -43,7 +43,7 @@ const {
 } = Script.prototype
 
 const { sep } = require("path")
-const { readFileSync } = require("fs")
+const fs = require("fs")
 
 const esmModule = new Module(id)
 
@@ -87,7 +87,7 @@ function makeRequireFunction(mod, options) {
 
 function readFile(filename, options) {
   try {
-    return readFileSync(filename, options)
+    return fs.readFileSync(filename, options)
   } catch (e) {}
 
   return null


### PR DESCRIPTION
This is only really needed because esm is part of tink's bootstrap, and weird bugs happen if tink can't replace the `fs` that esm uses.