### PR TITLE
test262 import.meta tests

### DIFF
--- a/script/setup-test262.js
+++ b/script/setup-test262.js
@@ -17,6 +17,7 @@ const testDirs = [
   "harness",
   "test/language/export",
   "test/language/expressions/dynamic-import",
+  "test/language/expressions/import.meta",
   "test/language/import",
   "test/language/module-code"
 ]

--- a/test/test262/skiplist
+++ b/test/test262/skiplist
@@ -60,3 +60,33 @@ test/language/expressions/dynamic-import/namespace/promise-then-ns-delete-non-ex
 
 # DYNAMIC IMPORT ⏭️ (not applicable)
 test/language/expressions/dynamic-import/namespace/promise-then-ns-delete-non-exported-strict.js
+
+# IMPORT.META 🚧 (currently unsupported)
+test/language/expressions/import.meta/import-meta-is-an-ordinary-object.js
+
+# IMPORT.META 🚧 (currently unsupported)
+test/language/expressions/import.meta/not-accessible-from-direct-eval.js
+
+# IMPORT.META 🚧 (currently unsupported)
+test/language/expressions/import.meta/syntax/escape-sequence-meta.js
+
+# IMPORT.META 🚧 (currently unsupported)
+test/language/expressions/import.meta/syntax/invalid-assignment-target-array-destructuring-expr.js
+
+# IMPORT.META 🚧 (currently unsupported)
+test/language/expressions/import.meta/syntax/invalid-assignment-target-assignment-expr.js
+
+# IMPORT.META 🚧 (currently unsupported)
+test/language/expressions/import.meta/syntax/invalid-assignment-target-for-await-of-loop.js
+
+# IMPORT.META 🚧 (currently unsupported)
+test/language/expressions/import.meta/syntax/invalid-assignment-target-for-in-loop.js
+
+# IMPORT.META 🚧 (currently unsupported)
+test/language/expressions/import.meta/syntax/invalid-assignment-target-for-of-loop.js
+
+# IMPORT.META 🚧 (currently unsupported)
+test/language/expressions/import.meta/syntax/invalid-assignment-target-object-destructuring-expr.js
+
+# IMPORT.META 🚧 (currently unsupported)
+test/language/expressions/import.meta/syntax/invalid-assignment-target-update-expr.js


### PR DESCRIPTION
adds [currently] 17 tests `262 tests` for **import.meta**

7 are passing
10 skipped

relevant issue/PR:
https://github.com/tc39/test262/issues/1342
https://github.com/tc39/test262/pull/1888

I think most tests are syntax related and would have to be fixed on Acorn's side of things?