### PR TITLE
tests for symlinked packages

### DIFF
--- a/test/fixture/main-hook/package/index.js
+++ b/test/fixture/main-hook/package/index.js
@@ -1,0 +1,8 @@
+import assert from "assert"
+import { log } from "console"
+import { Foo } from "./module-1"
+import { Bar } from "./module-2"
+
+assert.strictEqual(Foo, Bar)
+
+log("package:true")

--- a/test/fixture/main-hook/package/module-1/index.js
+++ b/test/fixture/main-hook/package/module-1/index.js
@@ -1,0 +1,1 @@
+export class Foo {}

--- a/test/fixture/main-hook/package/module-2/index.js
+++ b/test/fixture/main-hook/package/module-2/index.js
@@ -1,0 +1,1 @@
+export { Foo as Bar } from "module-1"

--- a/test/main-hook-tests.mjs
+++ b/test/main-hook-tests.mjs
@@ -222,4 +222,16 @@ describe("main hook tests", function () {
           })
       , Promise.resolve())
   })
+
+  it("should work with symlinked packages", () =>
+    fs
+      .ensureSymlink(
+        "./fixture/main-hook/package/module-1",
+        "./fixture/main-hook/package/module-2/node_modules/module-1"
+      )
+      .then(() =>
+        runMain("./fixture/main-hook/package/index.js")
+      )
+      .then(({ stdout }) => assert.ok(stdout.includes("package:true")))
+  )
 })


### PR DESCRIPTION
tests for https://github.com/standard-things/esm/issues/717 and https://github.com/standard-things/esm/issues/551 

tests are failing running against `v3.1.4` and passing running against `v3.2.0` [head/master]

I don't know of another/better/quicker way of creating symlinks for multi platform environments.

there's some other failures in unrelated tests. I'll have to check what's causing this.