### PR TITLE
In prepareValue, guard debug check against null property access

### DIFF
--- a/src/util/inspect.js
+++ b/src/util/inspect.js
@@ -68,8 +68,9 @@ function inspect(...args) {
 }
 
 function prepareValue(value) {
-  if (! Loader.state.package.default.options.debug &&
-      isStackTraceMaskable(value)) {
+  const defaultPkg = Loader.state.package.default || false
+  const defPkgOpt = defaultPkg.options || false
+  if (! defPkgOpt.debug && isStackTraceMaskable(value)) {
     maskStackTrace(value)
   }
 


### PR DESCRIPTION
Fixes #748 

It probably just masks the real problem, whatever that might be. For now this makes nodemjs work again, you can still add better tracing later.

Considering how often you use `Loader.state.package.default.options.debug`, it might be worth a guarding helper function.