### PR TITLE
Make unhandled promise rejections in tests fatal on Node v10, v11

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "nop": "^1.0.0",
     "nyc": "^13.3.0",
     "optimize-js-plugin": "0.0.4",
+    "p-fatal": "^0.1.1",
     "pm2": "3.2.4",
     "postcss": "^7.0.14",
     "proxyquire": "^2.1.0",

--- a/script/test.js
+++ b/script/test.js
@@ -1,5 +1,7 @@
 "use strict"
 
+require("p-fatal") // Make unhandled promise rejections fatal on Node v9
+
 const SemVer = require("semver")
 
 const execa = require("execa")


### PR DESCRIPTION
If you prefer a more popular module, you could use "perish".
I made "p-fatal" to allow programs to handle their rejections
one "nextTick" later, to avoid some undue failures.

Fixes #753