### PR TITLE
Always consume the whole format string

### DIFF
--- a/src/util/format-with-options.js
+++ b/src/util/format-with-options.js
@@ -103,10 +103,6 @@ function formatWithOptions(options, ...args) {
 
     result += segment
     lastPos = i + 1
-
-    if (argsIndex === lastArgsIndex) {
-      break
-    }
   }
 
   if (lastPos === 0) {


### PR DESCRIPTION
As highlighted [here](https://twitter.com/rauschma/status/1107667113358094337) by @rauschma , there seems to be a bug in `formatWithOptions`:

```
node -r esm -e "const {format} = require('util'); console.log(format('%s%%', 99))"
99%%
```

`formatWithOptions` stops consuming the format string and simply copies the rest of its input instead of processing it as soon as all formats have been replaced by their arg. In the above case, there's one format and one arg so the rest (`%%`) gets copied. Instead, `%%` should be processed as `%` as stated in node.js docs.

(Since it's a special case (the only 'format' that takes 0 arg), this PR could be made a bit more efficient by having special detection for this case and break out early as it was before but after making sure this case is handled. Not sure it's worth it though, it would add quite a few lines of code thus making it more complex for a seemingly small benefit.)