### PR TITLE
Update mocha link to require options

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ Tips
 
 * Load `esm` with “require” options of
   [`ava`](https://github.com/avajs/ava/blob/master/docs/recipes/es-modules.md),
-  [`mocha`](https://mochajs.org/#-r---require-module-name),
+  [`mocha`](https://mochajs.org/#-require-module-r-module),
   [`nodemon`](https://nodemon.io/),
   [`nyc`](https://github.com/istanbuljs/nyc#require-additional-modules),
   [`qunit`](https://github.com/qunitjs/qunit/releases/tag/2.6.0),


### PR DESCRIPTION
The current link to mocha require options is incorrect. This updates it to the correct link.