### PR TITLE
Update esm/import to allow loading ESM from .js

### DIFF
--- a/src/errors.js
+++ b/src/errors.js
@@ -68,7 +68,6 @@ function init() {
   addBuiltinError("ERR_EXPORT_CYCLE", exportCycle, ExSyntaxError)
   addBuiltinError("ERR_EXPORT_MISSING", exportMissing, ExSyntaxError)
   addBuiltinError("ERR_EXPORT_STAR_CONFLICT", exportStarConflict, ExSyntaxError)
-  addBuiltinError("ERR_INVALID_ESM_FILE_EXTENSION", invalidExtension, ExError)
   addBuiltinError("ERR_INVALID_ESM_OPTION", invalidPkgOption, ExError)
   addBuiltinError("ERR_NS_ASSIGNMENT", namespaceAssignment, ExTypeError)
   addBuiltinError("ERR_NS_DEFINITION", namespaceDefinition, ExTypeError)
@@ -230,10 +229,6 @@ function init() {
   function invalidArgValue(name, value, reason = "is invalid") {
     return "The argument '" + name + "' " + reason +
            ". Received " + inspectTrunc(value)
-  }
-
-  function invalidExtension(request) {
-    return "Cannot load module from .mjs: " + getModuleURL(request)
   }
 
   function invalidPkgOption(name, value, unquoted) {

--- a/src/module/esm/import.js
+++ b/src/module/esm/import.js
@@ -14,10 +14,6 @@ import validateDeep from "./validate-deep.js"
 import validateShallow from "./validate-shallow.js"
 
 const {
-  ERR_INVALID_ESM_FILE_EXTENSION
-} = errors
-
-const {
   TYPE_CJS,
   TYPE_ESM,
   STATE_PARSING_COMPLETED,
@@ -99,13 +95,6 @@ function esmImport(request, parentEntry, setterArgsList, isDynamic = false) {
     }
 
     entry._finalize = finalize
-  }
-
-  if (parentEntry.extname === ".mjs" &&
-      entry !== null &&
-      entry.type === TYPE_ESM &&
-      entry.extname !== ".mjs") {
-    throw ERR_INVALID_ESM_FILE_EXTENSION(entry.module)
   }
 
   if (! parsing) {

--- a/test/file-extension-tests.js
+++ b/test/file-extension-tests.js
@@ -68,21 +68,4 @@ describe("file extension tests", () => {
   it("should not error requiring unknown extensions", () => {
     require("./fixture/ext/a.unknown-ext-cjs")
   })
-
-  it('should error importing non `.mjs` ES modules from `.mjs` files with `options.mode` of "strict"', () =>
-    import("./fixture/ext/invalid.mjs")
-      .then(assert.fail)
-      .catch((e) => {
-        assert.ok(e instanceof SyntaxError)
-        assert.ok(e.message.startsWith("Unexpected token export"))
-      })
-  )
-
-  it('should error importing non `.mjs` ES modules from `.mjs` files with `options.mode` of "auto"', () =>
-    import("./fixture/cjs/ext/invalid.mjs")
-      .then(assert.fail)
-      .catch(({ message }) => {
-        assert.ok(message.startsWith("Cannot load module"))
-      })
-  )
 })


### PR DESCRIPTION
## Motivation

In Node 12 it is possible to load ESM code from `.js` files as long as the closest package.json file has the property "type" set to "module". Currently `esm` is failing with `ERR_INVALID_ESM_FILE_EXTENSION`. This can be easily reproduced by executing:

```console
$ cd $(mktemp -d) \
   && npm install esm \
   && echo '{"type": "module"}' > package.json \
   && echo 'export const n = 42' > index.js \
   && echo "import {n} from './index.js'" > index.mjs \
   && node -r esm index.mjs
```
```
file:///tmp/tmp.qN6ty6WLNE/index.mjs:1
import {n} from './index.js'

Error: Cannot load module from .mjs: file:///tmp/tmp.qN6ty6WLNE/index.js
    at file:///tmp/tmp.qN6ty6WLNE/index.mjs:1
    at Generator.next (<anonymous>)
    at startup (internal/bootstrap/node.js:283:19)
    at bootstrapNodeJSCore (internal/bootstrap/node.js:622:3)
```

## Changes

Currently `esm` supports loading ESM code from a `.js` file as long as the file that is importing the code is also `.js`. This made me think that `ERR_INVALID_ESM_FILE_EXTENSION` was only a restriction to be as close to Node 11.x modules implementation as possible.

Following that naive logic I have just removed the check. If this is a desired feature but has deeper implications I am willing to further develop it with some guidance.