### PR TITLE
Fix typo

### DIFF
--- a/src/visitor/eval.js
+++ b/src/visitor/eval.js
@@ -109,7 +109,7 @@ function init() {
     }
   }
 
-  return new EvalVisitor
+  return new EvalVisitor()
 }
 
 export default shared.inited


### PR DESCRIPTION
I'm assuming that `return new EvalVisitor` is a typo. Thought I'd PR :)