### PR TITLE
Patched the loader for files with .js extension

### DIFF
--- a/src/module.js
+++ b/src/module.js
@@ -27,6 +27,7 @@ import staticResolveFilename from "./module/static/resolve-filename.js"
 import staticResolveLookupPaths from "./module/static/resolve-lookup-paths.js"
 import staticWrap from "./module/static/wrap.js"
 import staticWrapper from "./module/static/wrapper.js"
+import jsFileLoader from "./shim/module-js-file-loader"
 
 const {
   ELECTRON
@@ -50,6 +51,10 @@ const Module = maskFunction(function (id = "", parent) {
     GenericArray.push(children, this)
   }
 }, RealModule)
+
+// Patch the loader for files with .js extension to prevent default
+// behaviour of erroring on commonjs syntax in dependencies.
+RealModule._extensions[".js"] = jsFileLoader
 
 Module._cache = __non_webpack_require__.cache
 Module._extensions = { __proto__: null }

--- a/src/shim/module-js-file-loader.js
+++ b/src/shim/module-js-file-loader.js
@@ -1,0 +1,8 @@
+import { readFileSync } from "fs"
+
+function jsFileLoader(module, filename) {
+  const content = readFileSync(filename, "utf8")
+  module._compile(content, filename)
+}
+
+export default jsFileLoader


### PR DESCRIPTION
This prevents the new default behaviour in Node 12+ of erroring when importing dependencies with commonjs syntax files from an ESM module.

See issue #868 