### PR TITLE
Support OpenSSL FIPS-140 mode by replacing MD5 with SHA256

### DIFF
--- a/src/shared.js
+++ b/src/shared.js
@@ -159,7 +159,7 @@ function init() {
 
     return encodeId(
       "_" +
-      safeCrypto.createHash("md5")
+      safeCrypto.createHash("sha256")
         .update(Date.now().toString())
         .digest("hex")
         .slice(0, 3)


### PR DESCRIPTION
Using esm with NodeJS 9.11 compiled against OpenSSL FIPS-140 Module causes this error:

```
Error: error:060A80A3:digital envelope routines:FIPS_DIGESTINIT:disabled for fips
    at new Hash (internal/crypto/hash.js:28:18)
```

This can be fixed by using SHA256 instead of MD5 per the [OpenSSL FIPS Object Module User Guide](https://www.openssl.org/docs/fips/UserGuide-2.0.pdf):

> The FIPS Object Module supports the Suite B cryptographic algorithms and can be used with Suite B cryptography exclusively.  Suite B requires 128-bit security levels and forbids use of TLS lesser than 1.2 (TLS 1.0 and 1.1 use MD5 as a PRF during key agreement).

Adding FIPS support will allow US government organizations to easily use esm in their node servers.

It is expected that this will cause some performance regression but I'm unclear on whether it will be a noticable difference or not.

For reference regarding the performance question here are some benchmark numbers on sha256 vs md5 in nodejs: https://github.com/hex7c0/nodejs-hash-performance