### PR TITLE
README: mention "load third-party esm from commonjs" usecase

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ There are two ways to enable `esm`.
     export {}
     ```
     :bulb: These files are automagically created with `npm init esm` or `yarn create esm`.
+   
+   CommonJS packages may load ESM-only packages in this manner too.
 
 2. Enable `esm` for local runs:
 


### PR DESCRIPTION
Since node 14 became a thing, some new packages have gone esm-only without commonjs compatibility. The `esm` package is capable of working as such a bridge even when used from the package-user side. I feel it's a good idea to document this.