### PR TITLE
Add support for Yarn 3

### DIFF
--- a/src/hook/pnp.js
+++ b/src/hook/pnp.js
@@ -4,24 +4,26 @@ import Module from "../module.js"
 
 import { sep } from "../safe/path.js"
 
+import escapeRegExp from "../util/escape-regexp.js"
+
 const {
   FLAGS
 } = ENV
 
-const YARN_PNP_FILENAME = ".pnp.js"
+const yarnPnpFilenameRegExp = new RegExp(`${escapeRegExp(sep)}\\.pnp\\.c?js$`)
 
 function hook(pnp) {
   const { _cache } = Module
 
   for (const name in _cache) {
-    if (name.endsWith(sep + YARN_PNP_FILENAME)) {
+    if (yarnPnpFilenameRegExp.test(name)) {
       Reflect.deleteProperty(_cache, name)
       break
     }
   }
 
   for (const request of FLAGS.preloadModules) {
-    if (request.endsWith(sep + YARN_PNP_FILENAME)) {
+    if (yarnPnpFilenameRegExp.test(request)) {
       Module._preloadModules([request])
       pnp._resolveFilename = Module._resolveFilename
       break


### PR DESCRIPTION
Since version 3, Yarn Plug'n'Play hooks file is now called `.pnp.cjs` (vs `.pnp.js`).
See Yarn changelog [here](https://github.com/yarnpkg/berry/blob/master/CHANGELOG.md#300).